### PR TITLE
Temporarily disable mouselook when targeting a spell

### DIFF
--- a/MouseLook.lua
+++ b/MouseLook.lua
@@ -234,6 +234,7 @@ function MouseLook_OnUpdate(self,elapsed,...)
 		and not MouseLook_MomentaryPointer then
 			
 			if CursorHasItem()
+			or SpellIsTargeting()
 			or UnmouseableFrameOnScreen()
 			or MouseIsOverFrame() then
 				


### PR DESCRIPTION
Work both for spells that select a target unit (such as Resurrection) and ground-targeted spells (totems, GTAoE, etc.)
An alternative solution would be to stay in mouselook mode, but allow the left-click to cast the spell at the location instead of walking backwards. This was easier to implement for sure :-)
