### PR TITLE
Recognize AdiBags frame as inventory and disable mouselook

### DIFF
--- a/MouseLook.lua
+++ b/MouseLook.lua
@@ -90,7 +90,7 @@ local MouseLook_FramesToCheck = {
 	"AchievementFrame",   "LookingForGuildFrame", "PVPUIFrame",       "GuildFrame",
 	"WorldMapFrame",      "VideoOptionsFrame",  "InterfaceOptionsFrame",
         "ACP_AddonList",      "PlayerTalentFrame",  "PVEFrame",           "EncounterJournal",
-	"PetJournalParent",   "AccountantFrame", 
+	"PetJournalParent",   "AccountantFrame", "AdiBagsContainer1",
 	"GarrisonLandingPage", "GarrisonMissionFrame", "GarrisonBuildingFrame",
 	--   "NxMap1",  (carbonite's world map breaks mouselook)
 	-- "StoreFrame", (causes taint??!??  wtf, blizzard?)


### PR DESCRIPTION
This adds the AdiBags inventory frame to the list of frames that should disable mouselook when active. It seems like it doesn't really scale to have to add each addon that could present an inventory to the list, but... well, at least we can work with the one I use :-)
